### PR TITLE
Persist synthetic event

### DIFF
--- a/src/ValidatorForm.jsx
+++ b/src/ValidatorForm.jsx
@@ -53,6 +53,7 @@ class ValidatorForm extends React.Component {
     submit = (event) => {
         if (event) {
             event.preventDefault();
+            event.persist();
         }
         this.errors = [];
         this.walk(this.childs).then((result) => {


### PR DESCRIPTION
Persist the synthetic event so that it is accessible when the onClick callback is bubbled. See https://reactjs.org/docs/events.html#event-pooling