### PR TITLE
isString should strictly check the value's type

### DIFF
--- a/src/ValidationRules.jsx
+++ b/src/ValidationRules.jsx
@@ -50,9 +50,9 @@ const validations = {
 
     minFloat: (value, min) => isEmpty(value) || parseFloat(value) >= parseFloat(min),
 
-    isString: value => isEmpty(value) || typeof value === 'string' || value instanceof String,
-    minStringLength: (value, length) => validations.isString(value) && value.length >= length,
-    maxStringLength: (value, length) => validations.isString(value) && value.length <= length,
+    isString: value => typeof value === 'string' || value instanceof String,
+    minStringLength: (value, length) => validations.isString(value) && value.length >= length || isEmpty(value),
+    maxStringLength: (value, length) => validations.isString(value) && value.length <= length || isEmpty(value),
 
     // eslint-disable-next-line no-undef
     isFile: value => isEmpty(value) || value instanceof File,


### PR DESCRIPTION
If the value is null or undefined the minStringLength and maxStringLength validations will error out, preventing any validation from occurring. Instead let's use isString to strictly check the value type and then let minStringLength and maxStringLength only apply to strings.