### PR TITLE
Fix placement of console.log

### DIFF
--- a/src/ValidatorComponent.jsx
+++ b/src/ValidatorComponent.jsx
@@ -63,9 +63,11 @@ class ValidatorComponent extends React.Component {
             if (this.invalid.length > 0) {
                 return errorMessages[this.invalid[0]];
             }
+        } else {
+            // eslint-disable-next-line
+            console.log('unknown errorMessages type', errorMessages);
         }
-        // eslint-disable-next-line
-        console.log('unknown errorMessages type', errorMessages);
+        
         return true;
     }
 


### PR DESCRIPTION
This issue was mentioned over [here](https://github.com/NewOldMax/react-material-ui-form-validator/issues/116) and [here](https://github.com/NewOldMax/react-form-validator-core/issues/58), but got never addressed.

After I introduced `this.getErrorMessage` in our project, we got flooded by the `unknown errorMessages type` loggings even though everything worked as expected. After I checked the library's code, I found out that the logging happens **even though** `type === 'object'` evaluates to `true` for our `errorMessages` array. 

However, the undesired logging still happens because the inner condition `this.invalid.length > 0` can still evaluate to `false` and thus we wouldn't return early and therefore would end up in the logging -- which shouldn't happen for `type === object`. 

In order to prevent this situation, we should only perform the logging if one of the type conditions don't apply.